### PR TITLE
Feat: allow root directory for plugins to be set when using NewClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,16 @@ The tfschema requires the provider's dependency library version to:
 
 # Rules of finding provider's binary
 When `terraform init` command is executed, provider's binary is installed under the auto installed directory ( .terraform/plugins/`<SOURCE ADDRESS>`/`<VERSION>`/`<OS>_<ARCH>` ) by default.
-The tfschema can use the same provider's binary as terraform uses, so you can run `tfschema` command in the same directory where you run the `terraform` command.
+The tfschema can use the same provider's binary as terraform uses, so you can run `tfschema` command in the same directory where you run the `terraform` command
+Alternatively, you can set the environment variable `$TFSCHEMA_ROOT_DIRECTORY` to be this directory. If `$TFSCHEMA_ROOT_DIRECTORY` is not set, it will default to the current directory
 
 The tfschema finds provider's binary under the following directories.
 
-1. current directory
+1. `$TFSCHEMA_ROOT_DIRECTORY`
 2. same directory as `tfschema` executable
-3. user vendor directory ( terraform.d/plugins/`<OS>_<ARCH>` )
-4. auto installed directory ( .terraform/plugins/`<SOURCE ADDRESS>`/`<VERSION>`/`<OS>_<ARCH>` )
-5. legacy auto installed directory ( .terraform/plugins/`<OS>_<ARCH>` )
+3. user vendor directory ( `$TFSCHEMA_ROOT_DIRECTORY`/terraform.d/plugins/`<OS>_<ARCH>` )
+4. auto installed directory ( `$TFSCHEMA_ROOT_DIRECTORY`/.terraform/plugins/`<SOURCE ADDRESS>`/`<VERSION>`/`<OS>_<ARCH>` )
+5. legacy auto installed directory ( `$TFSCHEMA_ROOT_DIRECTORY`/.terraform/plugins/`<OS>_<ARCH>` )
 6. global plugin directory ( $HOME/.terraform.d/plugins )
 7. global plugin directory with os and arch ( $HOME/.terraform.d/plugins/`<OS>_<ARCH>` )
 8. gopath ( $GOPATH/bin )

--- a/tfschema/client.go
+++ b/tfschema/client.go
@@ -90,8 +90,13 @@ func findPlugin(pluginType string, pluginName string) (*discovery.PluginMeta, er
 func pluginDirs() ([]string, error) {
 	dirs := []string{}
 
+	rootDirectory := os.Getenv("TFSCHEMA_ROOT_DIRECTORY")
+	if rootDirectory == "" {
+		rootDirectory = "."
+	}
+
 	// current directory
-	dirs = append(dirs, ".")
+	dirs = append(dirs, rootDirectory)
 
 	// same directory as this executable (not terraform)
 	exePath, err := os.Executable()
@@ -104,7 +109,7 @@ func pluginDirs() ([]string, error) {
 	// For Terraform v0.13, it is still supported but considered as legacy
 	// because now we can download third-party providers from Terraform Registry.
 	arch := runtime.GOOS + "_" + runtime.GOARCH
-	vendorDir := filepath.Join("terraform.d", "plugins", arch)
+	vendorDir := filepath.Join(rootDirectory, "terraform.d", "plugins", arch)
 	dirs = append(dirs, vendorDir)
 
 	// auto installed directory for Terraform v0.13+
@@ -118,7 +123,7 @@ func pluginDirs() ([]string, error) {
 	// but even if it is configured, the selection file is stored under
 	// .terraform/plugins directory and provider binaries are symlinked to the
 	// cache directory when running terraform init.
-	autoInstalledDirs, err := newSelectionFile(filepath.Join(".terraform", "plugins", "selections.json")).pluginDirs()
+	autoInstalledDirs, err := newSelectionFile(filepath.Join(rootDirectory, ".terraform", "plugins", "selections.json")).pluginDirs()
 	if err != nil {
 		return []string{}, err
 	}
@@ -126,7 +131,7 @@ func pluginDirs() ([]string, error) {
 	dirs = append(dirs, autoInstalledDirs...)
 
 	// auto installed directory for Terraform < v0.13
-	legacyAutoInstalledDir := filepath.Join(".terraform", "plugins", arch)
+	legacyAutoInstalledDir := filepath.Join(rootDirectory, ".terraform", "plugins", arch)
 	dirs = append(dirs, legacyAutoInstalledDir)
 
 	// global plugin directory


### PR DESCRIPTION
Allow to pass root directory to NewClient, to be used to determine the plugins folders